### PR TITLE
지도, 캘린더, 일정 연동 작업

### DIFF
--- a/src/app/reservation/[id]/page.tsx
+++ b/src/app/reservation/[id]/page.tsx
@@ -10,6 +10,8 @@ import { LuSquareParking } from "react-icons/lu";
 import { PiCookingPotBold } from "react-icons/pi";
 import { FiAlertCircle } from "react-icons/fi";
 import FloatingReservationBlock from "@/components/reservation/FloatingBlock";
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+import RoomInfo from "@/components/reservation/RoomInfo";
 
 export default function HouseDetail() {
   return (
@@ -169,76 +171,25 @@ export default function HouseDetail() {
           <div className="text-xl text-customGray-600 mt-5">
             제주특별자치도 제주시 노형동
           </div>
-          <div className="h-105 w-full bg-amber-400 rounded-2xl mt-2"></div>
+          <div className="h-105 w-full rounded-2xl mt-2">
+            <Map
+              center={{ lat: 33.4852923931, lng: 126.4814715703 }}
+              style={{ width: "100%", height: "100%" }}
+              level={3}
+            >
+              <MapMarker
+                position={{
+                  lat: 33.4852923931,
+                  lng: 126.4814715703,
+                }}
+              />
+            </Map>
+          </div>
 
           {/* 객실 정보 */}
           <div className="font-bold text-2xl mt-10">객실 정보</div>
-          <div className="mt-5 flex gap-8 items-center mb-20">
-            <div className="size-[302px] relative overflow-hidden rounded-2xl flex-shrink-0">
-              <Image
-                src={"/reservationImg/testImg.webp"}
-                alt="객실 이미지"
-                fill
-                objectFit="cover"
-              />
-            </div>
-            <div className="w-full">
-              <div className="font-semibold text-3xl">
-                130m² 그랜드 스위트 트윈
-              </div>
-              <div className="text-customGray-600 mt-2 mb-3 h-12 border-b border-customGray-400">
-                ※ 객실 가격 전화문의 요망
-              </div>
-              <div className="grid grid-cols-2 gap-y-3 justify-between">
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    객실 크기
-                  </div>
-                  <div className="font-semibold text-customGray-700">39</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    기준 인원
-                  </div>
-                  <div className="font-semibold text-customGray-700">2</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    객실 수
-                  </div>
-                  <div className="font-semibold text-customGray-700">15</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    욕조
-                  </div>
-                  <div className="font-semibold text-customGray-700">Y</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">TV</div>
-                  <div className="font-semibold text-customGray-700">Y</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    인터넷
-                  </div>
-                  <div className="font-semibold text-customGray-700">Y</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    냉장고
-                  </div>
-                  <div className="font-semibold text-customGray-700">Y</div>
-                </div>
-                <div className="flex gap-4 text-xl">
-                  <div className="w-19 font-medium text-customGray-600">
-                    드라이기
-                  </div>
-                  <div className="font-semibold text-customGray-700">Y</div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <RoomInfo />
+          <RoomInfo />
         </div>
 
         {/* 우측 예약 블록 */}

--- a/src/app/reservation/confirmation/page.tsx
+++ b/src/app/reservation/confirmation/page.tsx
@@ -5,25 +5,77 @@ import { IoCall } from "react-icons/io5";
 import { CiLocationOn } from "react-icons/ci";
 import Yaggwan from "@/components/reservation/Yaggwan";
 import { useState } from "react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import { ko } from "date-fns/locale";
+import useReservationStore from "@/store/reservationStore";
 
 export default function Confirmation() {
-  const [reservationData, setReservationData] = useState({
-    name: "",
-    phone: "",
-  });
-
+  // 예약자 정보와 이용자 정보 통합 상태
   const [userData, setUserData] = useState({
-    name: "",
-    phone: "",
-    people: "",
+    reserverName: "홍길동", // 예약자 이름
+    reserverPhone: "010-1234-5678", // 예약자 전화번호
+    userName: "", // 이용자 이름
+    userPhone: "", // 이용자 전화번호
+    people: "", // 인원
   });
 
-  const handleReservationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setReservationData({ ...reservationData, [e.target.name]: e.target.value });
+  const { checkIn, checkOut } = useReservationStore();
+
+  // 입력 상태 변경 핸들러
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUserData({ ...userData, [e.target.name]: e.target.value });
   };
 
-  const handleUserChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setUserData({ ...userData, [e.target.name]: e.target.value });
+  // 유효성 검사
+  const validateUserData = () => {
+    if (
+      !userData.reserverName ||
+      !userData.reserverPhone ||
+      !userData.userName ||
+      !userData.userPhone ||
+      !userData.people
+    ) {
+      alert("모든 필수 정보를 입력해주세요!");
+      return false;
+    }
+    if (parseInt(userData.people, 10) <= 0) {
+      alert("인원은 1명 이상이어야 합니다.");
+      return false;
+    }
+    return true;
+  };
+
+  // 금액 계산
+  const pricePerNight = 100000; // 1박당 가격
+  const calculateTotalPrice = () => {
+    const startDate = new Date(checkIn);
+    const endDate = new Date(checkOut);
+    const nights = Math.ceil(
+      (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
+    );
+    return nights > 0
+      ? nights * pricePerNight * Number(userData.people || 1)
+      : 0;
+  };
+
+  // FullCalendar 이벤트 데이터
+  const eventDate = [
+    {
+      title: "투숙 일정",
+      start: checkIn,
+      end: checkOut,
+      backgroundColor: "#80caff",
+      borderColor: "#80caff",
+    },
+  ];
+
+  // 예약 확인 처리
+  const handleConfirmReservation = () => {
+    if (validateUserData()) {
+      alert("예약이 완료되었습니다!");
+      // 서버 연동 로직 추가 가능
+    }
   };
 
   return (
@@ -59,31 +111,37 @@ export default function Confirmation() {
           <div className="w-full h-full border border-customGray-300 rounded-xl pt-8 pl-9">
             <div className="font-medium text-xl mb-8">예약자 정보</div>
             <div className="flex items-center mb-4 ml-10">
-              <label className="w-24 text-lg font-medium" htmlFor="name">
-                이름
+              <label
+                className="w-32 text-lg font-medium"
+                htmlFor="reserverName"
+              >
+                예약자 이름
               </label>
               <input
-                id="name"
+                id="reserverName"
                 type="text"
-                name="name"
-                placeholder="이름"
-                value={reservationData.name}
-                onChange={handleReservationChange}
+                name="reserverName"
+                placeholder="예약자 이름"
+                value={userData.reserverName}
+                onChange={handleInputChange}
                 className="w-49 h-8 border border-customGray-500 p-2 rounded"
                 readOnly
               />
             </div>
             <div className="flex items-center mb-4 ml-10">
-              <label className="w-24 text-lg font-medium" htmlFor="phone">
-                전화번호
+              <label
+                className="w-32 text-lg font-medium"
+                htmlFor="reserverPhone"
+              >
+                예약자 전화번호
               </label>
               <input
-                id="phone"
+                id="reserverPhone"
                 type="tel"
-                name="phone"
-                placeholder="전화번호"
-                value={reservationData.phone}
-                onChange={handleReservationChange}
+                name="reserverPhone"
+                placeholder="예약자 전화번호"
+                value={userData.reserverPhone}
+                onChange={handleInputChange}
                 className="w-49 h-8 border border-customGray-500 p-2 rounded"
                 readOnly
               />
@@ -93,35 +151,35 @@ export default function Confirmation() {
           <div className="w-full h-full border border-customGray-300 rounded-xl pt-8 pl-9">
             <div className="font-medium text-xl mb-8">이용자 정보</div>
             <div className="flex items-center mb-4 ml-10">
-              <label className="w-24 text-lg font-medium" htmlFor="userName">
-                이름
+              <label className="w-32 text-lg font-medium" htmlFor="userName">
+                이용자 이름
               </label>
               <input
                 id="userName"
                 type="text"
-                name="name"
-                placeholder="이름"
-                value={userData.name}
-                onChange={handleUserChange}
+                name="userName"
+                placeholder="이용자 이름"
+                value={userData.userName}
+                onChange={handleInputChange}
                 className="w-49 h-8 border border-customGray-500 p-2 rounded"
               />
             </div>
             <div className="flex items-center mb-4 ml-10">
-              <label className="w-24 text-lg font-medium" htmlFor="userPhone">
-                전화번호
+              <label className="w-32 text-lg font-medium" htmlFor="userPhone">
+                이용자 전화번호
               </label>
               <input
                 id="userPhone"
                 type="tel"
-                name="phone"
-                placeholder="전화번호"
-                value={userData.phone}
-                onChange={handleUserChange}
+                name="userPhone"
+                placeholder="이용자 전화번호"
+                value={userData.userPhone}
+                onChange={handleInputChange}
                 className="w-49 h-8 border border-customGray-500 p-2 rounded"
               />
             </div>
             <div className="flex items-center mb-4 ml-10">
-              <label className="w-24 text-lg font-medium" htmlFor="people">
+              <label className="w-32 text-lg font-medium" htmlFor="people">
                 인원
               </label>
               <input
@@ -130,15 +188,30 @@ export default function Confirmation() {
                 name="people"
                 placeholder="인원"
                 value={userData.people}
-                onChange={handleUserChange}
+                onChange={handleInputChange}
                 className="w-49 h-8 border border-customGray-500 p-2 rounded"
               />
             </div>
           </div>
         </div>
         <div className="w-full h-full border border-customGray-300 rounded-xl pt-8 px-9">
-          <div className="font-medium text-xl mb-8">일정 확인</div>
-          <div className="h-94 bg-amber-200"></div>
+          <div className="font-medium text-xl mb-4">일정 확인</div>
+          <div className="w-full h-94 mx-auto overflow-hidden">
+            <FullCalendar
+              initialView="dayGridMonth"
+              plugins={[dayGridPlugin]}
+              stickyHeaderDates={true}
+              aspectRatio={2}
+              contentHeight="376px"
+              locale={ko}
+              headerToolbar={{
+                left: "",
+                center: "",
+                right: "",
+              }}
+              events={eventDate}
+            />
+          </div>
         </div>
       </div>
       <div className="border border-customGray-300 my-10 w-full"></div>
@@ -146,13 +219,18 @@ export default function Confirmation() {
         <div className="font-medium text-xl mb-8">예약 확정하기</div>
         <div className="w-208 h-39 mx-auto grid grid-cols-2 gap-x-57 gap-y-8">
           <div>예약 숙소 :</div>
-          <div>예약자 명 :</div>
-          <div>예약 인원 :</div>
-          <div>예약자 전화번호 :</div>
-          <div>예약 일정 :</div>
-          <div>금액 :</div>
+          <div>예약자 명 : {userData.reserverName}</div>
+          <div>예약 인원 : {userData.people}</div>
+          <div>예약자 전화번호 : {userData.reserverPhone}</div>
+          <div>
+            예약 일정 : {checkIn} ~ {checkOut}
+          </div>
+          <div>금액 : {calculateTotalPrice().toLocaleString()}원</div>
         </div>
-        <button className="bg-customBlue-100 text-white mt-4 py-3 px-13 rounded-lg mx-auto block">
+        <button
+          onClick={handleConfirmReservation}
+          className="bg-customBlue-100 text-white mt-4 py-3 px-13 rounded-lg mx-auto block"
+        >
           결제하기
         </button>
       </div>

--- a/src/components/reservation/FloatingBlock.tsx
+++ b/src/components/reservation/FloatingBlock.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
+import useReservationStore from "@/store/reservationStore"; // Zustand 스토어
+import { useRouter } from "next/navigation";
 
 export default function FloatingReservationBlock() {
   const [checkIn, setCheckIn] = useState<string>(""); // 체크인 날짜 상태
   const [checkOut, setCheckOut] = useState<string>(""); // 체크아웃 날짜 상태
   const [totalNights, setTotalNights] = useState<number>(1); // 숙박 기간 상태
   const pricePerNight: number = 100000; // 1박당 가격
+
+  const { setReservation } = useReservationStore(); // Zustand 상태 업데이트 함수
+
+  const router = useRouter();
 
   const calculateNights = (start: string, end: string): void => {
     if (start && end) {
@@ -22,7 +28,9 @@ export default function FloatingReservationBlock() {
 
   const handleReservation = (): void => {
     if (checkIn && checkOut) {
+      setReservation(checkIn, checkOut); // Zustand를 통해 날짜 상태 저장
       alert(`체크인 날짜: ${checkIn}\n체크아웃 날짜: ${checkOut}`);
+      router.push("/reservation/confirmation");
     } else {
       alert("체크인 및 체크아웃 날짜를 선택해주세요.");
     }

--- a/src/components/reservation/RoomInfo.tsx
+++ b/src/components/reservation/RoomInfo.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+
+export default function RoomInfo() {
+  return (
+    <>
+      <div className="mt-5 flex gap-8 items-center mb-20">
+        <div className="size-[302px] relative overflow-hidden rounded-2xl flex-shrink-0">
+          <Image
+            src={"/reservationImg/testImg.webp"}
+            alt="객실 이미지"
+            fill
+            objectFit="cover"
+          />
+        </div>
+        <div className="w-full">
+          <div className="font-semibold text-3xl">130m² 그랜드 스위트 트윈</div>
+          <div className="text-customGray-600 mt-2 mb-3 h-12 border-b border-customGray-400">
+            ※ 객실 가격 전화문의 요망
+          </div>
+          <div className="grid grid-cols-2 gap-y-3 justify-between">
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">
+                객실 크기
+              </div>
+              <div className="font-semibold text-customGray-700">39</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">
+                기준 인원
+              </div>
+              <div className="font-semibold text-customGray-700">2</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">
+                객실 수
+              </div>
+              <div className="font-semibold text-customGray-700">15</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">욕조</div>
+              <div className="font-semibold text-customGray-700">Y</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">TV</div>
+              <div className="font-semibold text-customGray-700">Y</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">인터넷</div>
+              <div className="font-semibold text-customGray-700">Y</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">냉장고</div>
+              <div className="font-semibold text-customGray-700">Y</div>
+            </div>
+            <div className="flex gap-4 text-xl">
+              <div className="w-19 font-medium text-customGray-600">
+                드라이기
+              </div>
+              <div className="font-semibold text-customGray-700">Y</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/store/reservationStore.ts
+++ b/src/store/reservationStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface ReservationState {
+  checkIn: string;
+  checkOut: string;
+  setReservation: (checkIn: string, checkOut: string) => void;
+}
+
+const useReservationStore = create<ReservationState>((set) => ({
+  checkIn: "",
+  checkOut: "",
+  setReservation: (checkIn, checkOut) => set({ checkIn, checkOut }),
+}));
+
+export default useReservationStore;


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 상세 페이지 지도 보이게 했습니다.
- 예약 페이지 캘린더 보이게 했습니다.
- 캘린더에 일정 정보 넘어오는거 store로 연결해놨습니다.

  <br/>

## 이미지 첨부

![screencapture-localhost-3000-reservation-2-2025-04-07-12_22_03](https://github.com/user-attachments/assets/aa842f55-644c-4d14-8537-015ba11aaab8)
![screencapture-localhost-3000-reservation-confirmation-2025-04-07-12_22_37](https://github.com/user-attachments/assets/561d327e-8bd9-4b4a-9d89-b8c192df77ca)

<br/>

## 🔧 앞으로의 과제

- api 연동 작업

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>