### PR TITLE
숙소 랜더링 안되는 버그 수정

### DIFF
--- a/src/app/reservation/search/page.tsx
+++ b/src/app/reservation/search/page.tsx
@@ -92,17 +92,17 @@ export default function Search() {
 
   const handleCategoryChange = (category: string) => {
     setSelectedCategory(category);
-    setCurrentPage(1);
+    setCurrentPage(0);
   };
 
   const handleRegionClick = (region: string) => {
-    setSelectedRegion(region);
-    setCurrentPage(1);
+    setSelectedRegion((prevRegion) => (prevRegion === region ? null : region));
+    setCurrentPage(0);
   };
 
   const handleSearchSubmit = () => {
     setFinalSearch(searchInput);
-    setCurrentPage(1);
+    setCurrentPage(0);
   };
 
   const totalPages = Math.ceil(totalData / 10);


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 지역은 필터링 해제 가능합니다

- 숙소 10개 이하 검색 결과는 보여주지 않는 부분 수정했습니다

  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>